### PR TITLE
chore: use commonjs mode

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -9,6 +9,8 @@ ts_library(
     srcs = [
         "index.ts",
     ],
+    devmode_module = "commonjs",
+    runtime = "nodejs",
     tsconfig = "//:tsconfig.json",
     visibility = ["//visibility:private"],
     deps = [


### PR DESCRIPTION
Because if the file is recognized as AMD, it may not load properly.